### PR TITLE
feat: Implement Keycloak integration and secured APIs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,6 +68,15 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-spring-boot-starter</artifactId>
+			<version>22.0.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/example/demo/config/AuthenticationEvents.java
+++ b/backend/src/main/java/com/example/demo/config/AuthenticationEvents.java
@@ -1,0 +1,46 @@
+package com.example.demo.config;
+
+import com.example.demo.user.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationEvents implements ApplicationListener<AuthenticationSuccessEvent> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AuthenticationEvents.class);
+
+    private final UserService userService;
+
+    @Autowired
+    public AuthenticationEvents(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public void onApplicationEvent(AuthenticationSuccessEvent event) {
+        Authentication authentication = event.getAuthentication();
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Jwt) {
+            Jwt jwt = (Jwt) principal;
+            try {
+                logger.debug("AuthenticationSuccessEvent triggered for JWT subject: {}", jwt.getSubject());
+                userService.saveOrUpdateUserFromJwt(jwt);
+                logger.info("User with Keycloak ID {} processed successfully after authentication.", jwt.getSubject());
+            } catch (Exception e) {
+                logger.error("Error processing user from JWT after authentication success for subject {}: {}", jwt.getSubject(), e.getMessage(), e);
+            }
+        } else {
+            // This event might be triggered by other authentication mechanisms if any are configured.
+            // We are only interested in JWT-based authentications for user syncing.
+            logger.debug("AuthenticationSuccessEvent received, but principal is not a JWT. Principal type: {}",
+                    principal != null ? principal.getClass().getName() : "null");
+        }
+    }
+}

--- a/backend/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults()) // Enable CORS with default configuration
+                .csrf(csrf -> csrf.disable()) // Disable CSRF
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Stateless sessions
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/public/**").permitAll()
+                        .requestMatchers("/api/authenticated/**").authenticated()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults())); // Configure OAuth2 Resource Server with JWT
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter jwtConverter = new JwtAuthenticationConverter();
+        jwtConverter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+            if (realmAccess == null || realmAccess.isEmpty()) {
+                return List.of();
+            }
+
+            Collection<String> roles = (Collection<String>) realmAccess.get("roles");
+            if (roles == null || roles.isEmpty()) {
+                return List.of();
+            }
+
+            return roles.stream()
+                    .map(roleName -> "ROLE_" + roleName.toUpperCase()) // Prefix with ROLE_ for Spring Security
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+        });
+        return jwtConverter;
+    }
+}

--- a/backend/src/main/java/com/example/demo/controller/AdminController.java
+++ b/backend/src/main/java/com/example/demo/controller/AdminController.java
@@ -1,0 +1,21 @@
+package com.example.demo.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    @GetMapping("/")
+    public String getAdminMessage(@AuthenticationPrincipal Jwt jwt) {
+        String username = jwt.getClaimAsString("preferred_username");
+        if (username == null) {
+            username = jwt.getSubject();
+        }
+        return "Hello, " + username + "! You have ADMIN access.";
+    }
+}

--- a/backend/src/main/java/com/example/demo/controller/AuthenticatedController.java
+++ b/backend/src/main/java/com/example/demo/controller/AuthenticatedController.java
@@ -1,0 +1,34 @@
+package com.example.demo.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/authenticated")
+public class AuthenticatedController {
+
+    @GetMapping("/")
+    public String getAuthenticatedMessage(@AuthenticationPrincipal Jwt jwt) {
+        // Preferred way: Use @AuthenticationPrincipal Jwt jwt to get full JWT details
+        String username = jwt.getClaimAsString("preferred_username");
+        if (username == null) {
+            // Fallback if 'preferred_username' is not in the token, though it should be for Keycloak
+            username = jwt.getSubject(); // 'sub' usually holds the Keycloak user ID
+        }
+        return "Hello, " + username + "! You are authenticated.";
+    }
+
+    // Alternative using Principal, which is more generic
+    @GetMapping("/me")
+    public String getMyInfo(Principal principal) {
+        // The name from the Principal depends on the JwtAuthenticationToken configuration.
+        // By default, it's often the 'sub' claim.
+        return "Hello, " + principal.getName() + "! (from Principal)";
+    }
+}

--- a/backend/src/main/java/com/example/demo/controller/PublicController.java
+++ b/backend/src/main/java/com/example/demo/controller/PublicController.java
@@ -1,0 +1,15 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/public")
+public class PublicController {
+
+    @GetMapping("/")
+    public String getPublicMessage() {
+        return "Hello from Public API!";
+    }
+}

--- a/backend/src/main/java/com/example/demo/user/User.java
+++ b/backend/src/main/java/com/example/demo/user/User.java
@@ -1,0 +1,77 @@
+package com.example.demo.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users") // Using "users" as "user" can be a reserved keyword in some SQL databases
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String keycloakId;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String email;
+
+    public User() {
+    }
+
+    public User(String keycloakId, String username, String email) {
+        this.keycloakId = keycloakId;
+        this.username = username;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getKeycloakId() {
+        return keycloakId;
+    }
+
+    public void setKeycloakId(String keycloakId) {
+        this.keycloakId = keycloakId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", keycloakId='" + keycloakId + '\'' +
+                ", username='" + username + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
+}

--- a/backend/src/main/java/com/example/demo/user/UserRepository.java
+++ b/backend/src/main/java/com/example/demo/user/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByKeycloakId(String keycloakId);
+}

--- a/backend/src/main/java/com/example/demo/user/UserService.java
+++ b/backend/src/main/java/com/example/demo/user/UserService.java
@@ -1,0 +1,77 @@
+package com.example.demo.user;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class UserService {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserService.class);
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public User saveOrUpdateUserFromJwt(Jwt jwt) {
+        String keycloakId = jwt.getSubject(); // 'sub' claim is standard for Keycloak ID
+        String username = jwt.getClaimAsString("preferred_username");
+        String email = jwt.getClaimAsString("email");
+
+        if (keycloakId == null || keycloakId.isBlank()) {
+            logger.error("Keycloak ID (sub claim) is missing from JWT.");
+            // Or throw an exception, depending on how you want to handle this error
+            throw new IllegalArgumentException("Keycloak ID (sub) is required.");
+        }
+
+        if (username == null || username.isBlank()) {
+            logger.warn("Preferred username claim is missing from JWT for subject: {}", keycloakId);
+            // Fallback or decide if this is an error
+            username = "user_" + keycloakId; // Example fallback
+        }
+
+        if (email == null || email.isBlank()) {
+            logger.warn("Email claim is missing from JWT for subject: {}", keycloakId);
+            // Fallback or decide if this is an error.
+            // For some applications, email might be optional or derived.
+            // For this example, let's make it required for user creation.
+            throw new IllegalArgumentException("Email is required for user creation/update.");
+        }
+
+        Optional<User> existingUserOptional = userRepository.findByKeycloakId(keycloakId);
+
+        User user;
+        if (existingUserOptional.isPresent()) {
+            user = existingUserOptional.get();
+            boolean updated = false;
+            if (!username.equals(user.getUsername())) {
+                user.setUsername(username);
+                updated = true;
+            }
+            if (!email.equals(user.getEmail())) {
+                user.setEmail(email);
+                updated = true;
+            }
+            if (updated) {
+                logger.info("Updating existing user with Keycloak ID: {}", keycloakId);
+                user = userRepository.save(user);
+            } else {
+                logger.info("User with Keycloak ID: {} already up-to-date.", keycloakId);
+            }
+        } else {
+            logger.info("Creating new user with Keycloak ID: {}", keycloakId);
+            user = new User(keycloakId, username, email);
+            user = userRepository.save(user);
+        }
+        return user;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,33 +1,24 @@
 # Spring Datasource
 spring.datasource.url=jdbc:postgresql://db:5432/appdb
 spring.datasource.username=appuser
-spring.datasource.password=appsecret
+spring.datasource.password=apppass
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA / Hibernate
-spring.jpa.hibernate.ddl-auto=validate # Liquibase will handle schema creation
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
 # Liquibase
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 spring.liquibase.enabled=true
 
-# Keycloak
-# Replace 'your-keycloak-server', 'your-realm', and 'your-client-id' with actual values later
-# For now, we'll use placeholders. These will be configured via docker-compose environment variables.
-keycloak.auth-server-url=${KEYCLOAK_AUTH_SERVER_URL}
-keycloak.realm=${KEYCLOAK_REALM}
-keycloak.resource=${KEYCLOAK_RESOURCE} # This is usually the client-id
-keycloak.public-client=true # Or false, depending on your client type in Keycloak
-# keycloak.credentials.secret=${KEYCLOAK_CREDENTIALS_SECRET} # For confidential clients
-
-# Spring Security - Keycloak Integration (Basic, will need more specific config later)
-spring.security.oauth2.client.provider.keycloak.issuer-uri=${KEYCLOAK_AUTH_SERVER_URL}/realms/${KEYCLOAK_REALM}
-spring.security.oauth2.client.registration.keycloak.client-id=${KEYCLOAK_RESOURCE}
-# spring.security.oauth2.client.registration.keycloak.client-secret=${KEYCLOAK_CREDENTIALS_SECRET} # For confidential clients
-spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.keycloak.redirect-uri={baseUrl}/login/oauth2/code/{registrationId} 
-# Note: {baseUrl} and {registrationId} are Spring placeholders
+# Spring Security - Keycloak Integration (Resource Server)
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://keycloak:8080/realms/workshop-realm
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8080/realms/workshop-realm/protocol/openid-connect/certs
 
 # DevTools - for hot reloading
 spring.devtools.livereload.enabled=true

--- a/backend/src/test/java/com/example/demo/config/AuthenticationEventsTest.java
+++ b/backend/src/test/java/com/example/demo/config/AuthenticationEventsTest.java
@@ -1,0 +1,85 @@
+package com.example.demo.config;
+
+import com.example.demo.user.User;
+import com.example.demo.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthenticationEventsTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private AuthenticationEvents authenticationEvents;
+
+    @Mock
+    private Jwt jwt;
+
+    @Test
+    void onApplicationEvent_withJwtPrincipal_shouldCallUserService() {
+        when(jwt.getSubject()).thenReturn("test-sub"); // Required for logging inside userService and event listener
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
+
+        // Mock the userService call
+        when(userService.saveOrUpdateUserFromJwt(jwt)).thenReturn(new User("test-sub", "testuser", "test@example.com"));
+
+        authenticationEvents.onApplicationEvent(event);
+
+        verify(userService, times(1)).saveOrUpdateUserFromJwt(jwt);
+    }
+
+    @Test
+    void onApplicationEvent_withNonJwtPrincipal_shouldNotCallUserService() {
+        Object nonJwtPrincipal = new Object(); // Some other principal type
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(nonJwtPrincipal);
+        AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
+
+        authenticationEvents.onApplicationEvent(event);
+
+        verify(userService, never()).saveOrUpdateUserFromJwt(any(Jwt.class));
+    }
+
+    @Test
+    void onApplicationEvent_userServiceThrowsException_shouldHandleError() {
+        // Simulate a situation where userService.saveOrUpdateUserFromJwt might throw an exception
+        when(jwt.getSubject()).thenReturn("error-sub");
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
+
+        // Configure userService to throw an exception for this specific JWT
+        doThrow(new RuntimeException("Database error")).when(userService).saveOrUpdateUserFromJwt(jwt);
+
+        // The event listener should catch and log the error, not rethrow it
+        authenticationEvents.onApplicationEvent(event);
+
+        // Verify that userService.saveOrUpdateUserFromJwt was still called
+        verify(userService, times(1)).saveOrUpdateUserFromJwt(jwt);
+        // Further assertions could involve checking logs if a test logger was configured
+    }
+
+    @Test
+    void onApplicationEvent_withUsernamePasswordAuthenticationToken_shouldNotCallUserService() {
+        // This tests a common alternative Authentication object
+        Authentication authentication = new UsernamePasswordAuthenticationToken("user", "password");
+        AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
+
+        authenticationEvents.onApplicationEvent(event);
+
+        verify(userService, never()).saveOrUpdateUserFromJwt(any(Jwt.class));
+    }
+}

--- a/backend/src/test/java/com/example/demo/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/example/demo/controller/AdminControllerTest.java
@@ -1,0 +1,90 @@
+package com.example.demo.controller;
+
+import com.example.demo.config.SecurityConfig;
+import com.example.demo.user.UserService; // Mock for AuthenticationEvents
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminController.class)
+@Import(SecurityConfig.class)
+public class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService; // For AuthenticationEvents
+
+    @Test
+    void getAdminMessage_withoutAuthentication_shouldReturnUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/admin/"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getAdminMessage_withAuthentication_noAdminRole_shouldReturnForbidden() throws Exception {
+        mockMvc.perform(get("/api/admin/")
+                        .with(jwt().jwt(builder -> builder
+                                .claim("preferred_username", "user")
+                                .claim("realm_access", Map.of("roles", List.of("USER")))))) // Role "USER"
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getAdminMessage_withAuthentication_emptyRoles_shouldReturnForbidden() throws Exception {
+        mockMvc.perform(get("/api/admin/")
+                        .with(jwt().jwt(builder -> builder
+                                .claim("preferred_username", "user_no_roles")
+                                .claim("realm_access", Map.of("roles", Collections.emptyList()))))) // Empty roles
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getAdminMessage_withAuthentication_adminRole_shouldReturnAdminMessage() throws Exception {
+        // The JwtAuthenticationConverter in SecurityConfig prefixes roles with "ROLE_".
+        // The hasRole("ADMIN") check in SecurityConfig expects "ADMIN" without the prefix.
+        // The converter extracts "ADMIN" from the token and Spring Security adds "ROLE_" internally.
+        mockMvc.perform(get("/api/admin/")
+                        .with(jwt().jwt(builder -> builder
+                                .claim("preferred_username", "adminuser")
+                                .claim("realm_access", Map.of("roles", List.of("ADMIN", "USER")))))) // Has "ADMIN" role
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello, adminuser! You have ADMIN access."));
+    }
+
+    @Test
+    void getAdminMessage_withAuthentication_adminRoleDifferentCase_shouldWorkIfAuthoritiesAreCaseInsensitiveOrNormalized() throws Exception {
+        // Keycloak roles are often case-sensitive, but Spring Security's GrantedAuthority comparison can be case-sensitive.
+        // Our converter does .toUpperCase() on role names, so "admin" becomes "ROLE_ADMIN".
+        // The hasRole("ADMIN") check implicitly looks for "ROLE_ADMIN".
+        mockMvc.perform(get("/api/admin/")
+                        .with(jwt().jwt(builder -> builder
+                                .claim("preferred_username", "admin_lowercase_role")
+                                .claim("realm_access", Map.of("roles", List.of("admin")))))) // Role "admin" (lowercase)
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello, admin_lowercase_role! You have ADMIN access."));
+    }
+
+    @Test
+    void getAdminMessage_withJwtAuthentication_missingPreferredUsername_shouldFallbackToSubject() throws Exception {
+        mockMvc.perform(get("/api/admin/")
+                        .with(jwt().jwt(builder -> builder
+                                .subject("admin_sub_only")
+                                .claim("realm_access", Map.of("roles", List.of("ADMIN"))))))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello, admin_sub_only! You have ADMIN access."));
+    }
+}

--- a/backend/src/test/java/com/example/demo/controller/AuthenticatedControllerTest.java
+++ b/backend/src/test/java/com/example/demo/controller/AuthenticatedControllerTest.java
@@ -1,0 +1,75 @@
+package com.example.demo.controller;
+
+import com.example.demo.config.SecurityConfig;
+import com.example.demo.user.UserService; // Needed for AuthenticationEvents if it were scanned
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthenticatedController.class)
+@Import(SecurityConfig.class)
+public class AuthenticatedControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // Mock UserService as it's a dependency for AuthenticationEvents,
+    // which might be triggered if components are scanned broadly.
+    // For @WebMvcTest, it's good practice to mock beans not directly part of the controller's immediate interaction
+    // but potentially part of the request lifecycle (like event listeners).
+    @MockBean
+    private UserService userService;
+
+
+    @Test
+    void getAuthenticatedMessage_withoutAuthentication_shouldReturnUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/authenticated/"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getAuthenticatedMessage_withJwtAuthentication_shouldReturnAuthenticatedMessage() throws Exception {
+        mockMvc.perform(get("/api/authenticated/")
+                        .with(jwt().jwt(builder -> builder
+                                .claim("preferred_username", "testuser")
+                                .subject("test-sub"))))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello, testuser! You are authenticated."));
+    }
+
+    @Test
+    void getAuthenticatedMessage_withJwtAuthentication_missingPreferredUsername_shouldFallbackToSubject() throws Exception {
+        mockMvc.perform(get("/api/authenticated/")
+                        .with(jwt().jwt(builder -> builder
+                                .subject("sub_only_user"))))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello, sub_only_user! You are authenticated."));
+    }
+
+
+    @Test
+    void getMyInfo_withoutAuthentication_shouldReturnUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/authenticated/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getMyInfo_withJwtAuthentication_shouldReturnPrincipalName() throws Exception {
+        // When using the jwt() postprocessor, the Principal.getName() by default returns the 'sub' claim.
+        mockMvc.perform(get("/api/authenticated/me")
+                        .with(jwt().jwt(builder -> builder
+                                .claim("preferred_username", "testuser")
+                                .subject("test-subject"))))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello, test-subject! (from Principal)"));
+    }
+}

--- a/backend/src/test/java/com/example/demo/controller/PublicControllerTest.java
+++ b/backend/src/test/java/com/example/demo/controller/PublicControllerTest.java
@@ -1,0 +1,27 @@
+package com.example.demo.controller;
+
+import com.example.demo.config.SecurityConfig; // Make sure SecurityConfig is imported
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PublicController.class)
+@Import(SecurityConfig.class) // Import SecurityConfig to apply security rules
+public class PublicControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void getPublicMessage_shouldReturnPublicMessage() throws Exception {
+        mockMvc.perform(get("/api/public/"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello from Public API!"));
+    }
+}

--- a/backend/src/test/java/com/example/demo/user/UserServiceTest.java
+++ b/backend/src/test/java/com/example/demo/user/UserServiceTest.java
@@ -1,0 +1,159 @@
+package com.example.demo.user;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private Jwt jwt;
+
+    private User existingUser;
+
+    @BeforeEach
+    void setUp() {
+        existingUser = new User("existing-keycloak-id", "existinguser", "existing@example.com");
+        existingUser.setId(1L);
+    }
+
+    private void mockJwtClaims(String sub, String username, String email) {
+        when(jwt.getSubject()).thenReturn(sub);
+        when(jwt.getClaimAsString("preferred_username")).thenReturn(username);
+        when(jwt.getClaimAsString("email")).thenReturn(email);
+    }
+
+    @Test
+    void saveOrUpdateUserFromJwt_newUser_shouldCreateUser() {
+        mockJwtClaims("new-keycloak-id", "newuser", "new@example.com");
+        when(userRepository.findByKeycloakId("new-keycloak-id")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User userToSave = invocation.getArgument(0);
+            userToSave.setId(2L); // Simulate saving and getting an ID
+            return userToSave;
+        });
+
+        User result = userService.saveOrUpdateUserFromJwt(jwt);
+
+        assertNotNull(result);
+        assertEquals("new-keycloak-id", result.getKeycloakId());
+        assertEquals("newuser", result.getUsername());
+        assertEquals("new@example.com", result.getEmail());
+        assertNotNull(result.getId());
+        verify(userRepository, times(1)).findByKeycloakId("new-keycloak-id");
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    void saveOrUpdateUserFromJwt_existingUser_shouldUpdateUser() {
+        mockJwtClaims("existing-keycloak-id", "updateduser", "updated@example.com");
+        when(userRepository.findByKeycloakId("existing-keycloak-id")).thenReturn(Optional.of(existingUser));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.saveOrUpdateUserFromJwt(jwt);
+
+        assertNotNull(result);
+        assertEquals("existing-keycloak-id", result.getKeycloakId());
+        assertEquals("updateduser", result.getUsername());
+        assertEquals("updated@example.com", result.getEmail());
+        assertEquals(1L, result.getId());
+        verify(userRepository, times(1)).findByKeycloakId("existing-keycloak-id");
+        verify(userRepository, times(1)).save(existingUser);
+    }
+
+    @Test
+    void saveOrUpdateUserFromJwt_existingUser_noChange_shouldNotSave() {
+        mockJwtClaims("existing-keycloak-id", "existinguser", "existing@example.com");
+        when(userRepository.findByKeycloakId("existing-keycloak-id")).thenReturn(Optional.of(existingUser));
+        // Note: The current implementation of saveOrUpdateUserFromJwt *will* call save
+        // if any field is different, and then again if it was modified.
+        // The logic in service is: if (updated) { userRepository.save() }
+        // If no fields are different, updated = false, so save is not called.
+
+        User result = userService.saveOrUpdateUserFromJwt(jwt);
+
+        assertNotNull(result);
+        assertEquals("existinguser", result.getUsername());
+        assertEquals("existing@example.com", result.getEmail());
+        verify(userRepository, times(1)).findByKeycloakId("existing-keycloak-id");
+        verify(userRepository, never()).save(any(User.class)); // Because no fields changed
+    }
+
+    @Test
+    void saveOrUpdateUserFromJwt_existingUser_usernameChangeOnly_shouldUpdateUser() {
+        mockJwtClaims("existing-keycloak-id", "onlyUsernameUpdated", "existing@example.com");
+        when(userRepository.findByKeycloakId("existing-keycloak-id")).thenReturn(Optional.of(existingUser));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.saveOrUpdateUserFromJwt(jwt);
+
+        assertNotNull(result);
+        assertEquals("onlyUsernameUpdated", result.getUsername());
+        assertEquals("existing@example.com", result.getEmail()); // Email remains the same
+        verify(userRepository, times(1)).save(existingUser);
+    }
+
+
+    @Test
+    void saveOrUpdateUserFromJwt_missingSubClaim_shouldThrowException() {
+        when(jwt.getSubject()).thenReturn(null);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            userService.saveOrUpdateUserFromJwt(jwt);
+        });
+        assertEquals("Keycloak ID (sub) is required.", exception.getMessage());
+        verify(userRepository, never()).findByKeycloakId(anyString());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void saveOrUpdateUserFromJwt_missingEmailClaim_shouldThrowException() {
+        when(jwt.getSubject()).thenReturn("some-sub");
+        when(jwt.getClaimAsString("preferred_username")).thenReturn("someuser");
+        when(jwt.getClaimAsString("email")).thenReturn(null); // Missing email
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            userService.saveOrUpdateUserFromJwt(jwt);
+        });
+        assertEquals("Email is required for user creation/update.", exception.getMessage());
+        verify(userRepository, never()).findByKeycloakId(anyString()); // Should fail before this
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void saveOrUpdateUserFromJwt_missingUsernameClaim_shouldUseFallback() {
+        // Assumes 'sub' and 'email' are present
+        mockJwtClaims("keycloak-id-fallback", null, "user.fallback@example.com");
+        when(userRepository.findByKeycloakId("keycloak-id-fallback")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User userToSave = invocation.getArgument(0);
+            userToSave.setId(3L);
+            return userToSave;
+        });
+
+        User result = userService.saveOrUpdateUserFromJwt(jwt);
+
+        assertNotNull(result);
+        assertEquals("user_keycloak-id-fallback", result.getUsername()); // Check fallback username
+        assertEquals("user.fallback@example.com", result.getEmail());
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+}


### PR DESCRIPTION
This commit introduces Keycloak authentication and authorization to the backend, along with three new API endpoints:

1.  **Public API (`/api/public`)**: Accessible without authentication.
2.  **Authenticated API (`/api/authenticated`)**: Requires a valid JWT token.
3.  **Admin API (`/api/admin`)**: Requires a valid JWT token with the "ADMIN" role.

Key Features:
-   **Keycloak Integration**: Configured Spring Security to use Keycloak as an OAuth 2.0 Resource Server for JWT validation.
-   **User Persistence**: User information (Keycloak ID, username, email) from the JWT is saved or updated in the local database upon successful authentication. This is handled by `UserService` and triggered by an `AuthenticationSuccessEvent` listener.
-   **Role-Based Access Control (RBAC)**: Endpoints are secured based on authentication status and user roles defined in Keycloak. The `JwtAuthenticationConverter` extracts roles from the `realm_access.roles` claim.
-   **Project Structure**:
    -   Added `User` entity and `UserRepository`.
    -   Created `SecurityConfig` for security rules and Keycloak setup.
    -   Implemented `UserService` for user data management.
    -   Added `PublicController`, `AuthenticatedController`, and `AdminController`.
    -   Integrated an `AuthenticationEvents` listener for JWT user sync.
-   **Configuration**: Added Keycloak and database settings to `application.properties`.
-   **Testing**: Included comprehensive unit tests for services, controllers, and the event listener using Mockito and Spring Security's test utilities. Tests cover various scenarios including new user creation, existing user updates, role-based access, and missing JWT claims.